### PR TITLE
Add Entra login with MSAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,23 @@ Project Structure
 
 5. Run the development server:
   ```
-  $ python app.py
+ $ python app.py
   ```
 
 6. Navigate to [http://localhost:5000](http://localhost:5000)
+
+### Microsoft Entra Login
+
+This project now includes optional authentication via Microsoft Entra.
+Set the following environment variables before running the app:
+
+```
+export CLIENT_ID=<application-id>
+export CLIENT_SECRET=<client-secret>
+export TENANT_ID=<tenant-id>
+```
+
+With these variables configured you can sign in using the "Sign in with Microsoft" button on the login page. The acquired access token is used for Microsoft Graph API calls.
 
 
 Deploying to Heroku

--- a/app.py
+++ b/app.py
@@ -2,12 +2,15 @@
 # Imports
 #----------------------------------------------------------------------------#
 
-from flask import Flask, render_template, request
+from flask import Flask, render_template, request, redirect, url_for, session
 # from flask.ext.sqlalchemy import SQLAlchemy
 import logging
 from logging import Formatter, FileHandler
 from forms import *
 import os
+import uuid
+import msal
+import requests
 
 #----------------------------------------------------------------------------#
 # App Config.
@@ -16,6 +19,27 @@ import os
 app = Flask(__name__)
 app.config.from_object('config')
 #db = SQLAlchemy(app)
+
+
+def _build_msal_app(cache=None, authority=None):
+    return msal.ConfidentialClientApplication(
+        app.config['CLIENT_ID'],
+        authority=authority or app.config.get('AUTHORITY'),
+        client_credential=app.config.get('CLIENT_SECRET'),
+        token_cache=cache
+    )
+
+
+def _load_cache():
+    cache = msal.SerializableTokenCache()
+    if session.get('token_cache'):
+        cache.deserialize(session['token_cache'])
+    return cache
+
+
+def _save_cache(cache):
+    if cache.has_state_changed:
+        session['token_cache'] = cache.serialize()
 
 # Automatically tear down SQLAlchemy.
 '''
@@ -55,6 +79,45 @@ def about():
 def login():
     form = LoginForm(request.form)
     return render_template('forms/login.html', form=form)
+
+
+@app.route('/msal_login')
+def msal_login():
+    session['state'] = str(uuid.uuid4())
+    auth_url = _build_msal_app().get_authorization_request_url(
+        app.config['SCOPE'],
+        state=session['state'],
+        redirect_uri=url_for('authorized', _external=True)
+    )
+    return redirect(auth_url)
+
+
+@app.route(app.config['REDIRECT_PATH'])
+def authorized():
+    if request.args.get('state') != session.get('state'):
+        return redirect(url_for('home'))
+    cache = _load_cache()
+    result = _build_msal_app(cache=cache).acquire_token_by_authorization_code(
+        request.args['code'],
+        scopes=app.config['SCOPE'],
+        redirect_uri=url_for('authorized', _external=True)
+    )
+    _save_cache(cache)
+    if 'access_token' in result:
+        session['user'] = result.get('id_token_claims')
+        session['token'] = result['access_token']
+        return redirect(url_for('profile'))
+    return render_template('errors/500.html'), 500
+
+
+@app.route('/profile')
+def profile():
+    token = session.get('token')
+    if not token:
+        return redirect(url_for('login'))
+    from graph_api import get_user_profile
+    data = get_user_profile(token)
+    return render_template('pages/profile.html', result=data)
 
 
 @app.route('/register')

--- a/config.py
+++ b/config.py
@@ -12,3 +12,11 @@ SECRET_KEY = 'my precious'
 
 # Connect to the database
 SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(basedir, 'database.db')
+
+# MSAL configuration
+CLIENT_ID = os.getenv('CLIENT_ID')
+CLIENT_SECRET = os.getenv('CLIENT_SECRET')
+TENANT_ID = os.getenv('TENANT_ID')
+AUTHORITY = f"https://login.microsoftonline.com/{TENANT_ID}" if TENANT_ID else None
+REDIRECT_PATH = '/getAToken'
+SCOPE = ['User.Read']

--- a/graph_api.py
+++ b/graph_api.py
@@ -1,0 +1,57 @@
+import requests
+from flask import current_app
+
+GRAPH_API_ENDPOINT = 'https://graph.microsoft.com/v1.0'
+
+
+def _headers(token):
+    return {
+        'Authorization': f'Bearer {token}',
+        'Content-Type': 'application/json'
+    }
+
+
+def get_user_profile(token):
+    """Fetch profile for the signed-in user."""
+    resp = requests.get(f"{GRAPH_API_ENDPOINT}/me", headers=_headers(token))
+    if resp.status_code == 200:
+        return resp.json()
+    current_app.logger.error('Graph API error: %s %s', resp.status_code, resp.text)
+    return None
+
+
+def add_users_bulk(token, users):
+    """Create multiple users via Graph API."""
+    created = []
+    for user in users:
+        resp = requests.post(f"{GRAPH_API_ENDPOINT}/users", json=user, headers=_headers(token))
+        if resp.status_code in (200, 201):
+            created.append(resp.json())
+        else:
+            current_app.logger.error('Failed to create user: %s %s', resp.status_code, resp.text)
+    return created
+
+
+def update_users_bulk(token, users):
+    """Update multiple users via Graph API."""
+    updated = []
+    for user in users:
+        user_id = user.get('id')
+        if not user_id:
+            continue
+        resp = requests.patch(f"{GRAPH_API_ENDPOINT}/users/{user_id}", json=user, headers=_headers(token))
+        if resp.status_code == 204:
+            updated.append(user_id)
+        else:
+            current_app.logger.error('Failed to update user %s: %s %s', user_id, resp.status_code, resp.text)
+    return updated
+
+
+def last_login_report(token):
+    """Get last sign-in report for all users."""
+    url = f"{GRAPH_API_ENDPOINT}/reports/getAzureADSignInLogs"
+    resp = requests.get(url, headers=_headers(token))
+    if resp.status_code == 200:
+        return resp.json()
+    current_app.logger.error('Failed to get sign-in logs: %s %s', resp.status_code, resp.text)
+    return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ coverage
 # ecdsa
 # paramiko
 # pycrypto
+
+msal
+requests

--- a/templates/forms/login.html
+++ b/templates/forms/login.html
@@ -10,4 +10,7 @@
     <input type="submit" value="Submit" class="btn btn-primary btn-lg btn-block" disabled>
     <p>You must add database as well as Flask-Login to enable user management. See the <a href="http://www.realpython.com">Real Python</a> course for more info!</p>
   </form>
+  <p class="text-center">
+    <a href="{{ url_for('msal_login') }}" class="btn btn-success">Sign in with Microsoft</a>
+  </p>
 {% endblock %}

--- a/templates/pages/profile.html
+++ b/templates/pages/profile.html
@@ -1,0 +1,7 @@
+{% extends 'layouts/main.html' %}
+{% block title %}Profile{% endblock %}
+{% block content %}
+<h2>Welcome {{ result.displayName }}</h2>
+<p>Email: {{ result.mail or result.userPrincipalName }}</p>
+<pre>{{ result | tojson(indent=2) }}</pre>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow optional login with Microsoft Entra via MSAL
- add helper module for Microsoft Graph API operations
- show a button on the login page to sign in with Microsoft
- display user profile after signing in
- document Entra setup in README

## Testing
- `python -m py_compile app.py graph_api.py`

------
https://chatgpt.com/codex/tasks/task_b_686662d0b6548329a7613b4fd2d01f14